### PR TITLE
[Fix]is_activeのバリデーション設定変更

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,8 +9,8 @@ class Item < ApplicationRecord
   validates :introduction, presence: true
   validates :price, presence: true
   validates :genre_id, presence: true
-  validates :is_active, presence: true
-  
+  validates :is_active, inclusion: {in: [true, false]}
+
   def add_tax_price
     (self.price * 1.1).floor
   end


### PR DESCRIPTION
管理者側で商品編集をする際に、「販売停止中」にするとエラーが出てしまっていたので修正しました。