### PR TITLE
[Fix]管理者/注文詳細画面の単価表示修正

### DIFF
--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -51,9 +51,9 @@
             <% @order.order_details.each do |order_detail| %>
               <tr>
                 <td><%= order_detail.item.name %></td>
-                <td><%= (order_detail.price * 1.1).to_i %></td>
+                <td><%= order_detail.price %></td>
                 <td><%= order_detail.amount %></td>
-                <td><%= subtotal = ((order_detail.price*order_detail.amount)*1.1).to_i %></td>
+                <td><%= subtotal = (order_detail.price*order_detail.amount) %></td>
                 <td><%= form_with model: order_detail, url: admin_order_order_detail_path(@order.id,order_detail.id), method: :patch, local:true do |f| %>
                     <%= f.select :make_status, OrderDetail.make_statuses.keys.map{|k| [I18n.t("enums.order_detail.make_status.#{k}"), k]}%>
                     <%= f.submit '更新', class: "btn btn-success" %>


### PR DESCRIPTION
消費税込みの値段に対して、さらに1.1をかけていました。
修正したので、確認お願いします！